### PR TITLE
Add deprecation notice and point to mongers built in implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mongo session store using monger
 
+**Deprecated**: Monger now ships with a built-in ring session storage implementation. See [the monger docs](http://clojuremongodb.info/articles/integration.html#using_mongodbbacked_ring_session_store_with_monger) for details.
+
 monger-session use mongodb as a Clojure/Ring's http session storage.
 
 !clojure 1.4 is now required!


### PR DESCRIPTION
Since this project hasn't been updated in 6 years I'm assuming it's deprecated. This PR adds a note in the README to let people know the status of the project and where to find a good, up to date alternative. 

This repo showed on the top of my search results on the topic (way higher than the default monger implementation) so there's probably value in pointing people in the right direction. 